### PR TITLE
feat: ci workflow 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI (Python 3.12 + uv)
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Sync dependencies
+        run: |
+          if [ -f "uv.lock" ]; then
+            uv sync --dev
+          elif [ -f "pyproject.toml" ]; then
+            uv pip install -e .
+            uv pip install pytest
+          elif [ -f "requirements.txt" ]; then
+            uv pip install -r requirements.txt
+            uv pip install pytest
+          fi
+
+      - name: Run tests
+        run: |
+          if [ -f "run_pytest.sh" ]; then
+            sh ./run_pytest.sh
+          else
+            uv run pytest -q
+          fi


### PR DESCRIPTION
## 목적
- Python 3.12 + uv 기반 최소 CI 추가

## 변경사항
- .github/workflows/ci.yml 추가
- uv 설치 및 `run_pytest.sh` 실행 경로 적용

## 체크리스트
- [x] 로컬에서 테스트 스크립트 동작 확인
- [x] Actions 탭에서 워크플로우 성공 확인
- [x] README에 CI 배지(선택) 추가 검토

## 주의/보안
- 시크릿/토큰 사용 없음 (배포/원격접속 미포함)
