### PR TITLE
test(eval): sLLM Evaluation unit/integration 테스트 코드 추가

### DIFF
--- a/eval/evaluation.py
+++ b/eval/evaluation.py
@@ -57,10 +57,10 @@ class LLMEvaluation:
                 )
                 prediction = resp.choices[0].message.content.strip()
 
-                bleu = self.bleu.compute(prediction=prediction, references=[reference])
+                bleu = self.bleu.score(output=prediction, references=[reference])
                 bleu_scores.append(float(bleu))
 
-                rouge = self.rouge.compute(prediction=prediction, references=[reference])
+                rouge = self.rouge.score(output=prediction, references=[reference])
                 rouge_scores.append({k: float(v) for k, v in rouge.items()})
 
             except Exception as e:

--- a/scripts/run_pytest.sh
+++ b/scripts/run_pytest.sh
@@ -1,7 +1,7 @@
 # pytest 실행 스크립트
 # 커버리지와 함께 테스트 실행
 
-echo "🧪 데이터 처리 모듈 테스트 시작..."
+echo "🧪 테스트 시작..."
 
 # uv를 통해 pytest 실행 (커버리지 포함)
 uv run pytest tests/ \

--- a/tests/integration/test_eval_integration.py
+++ b/tests/integration/test_eval_integration.py
@@ -1,0 +1,199 @@
+import pytest
+from unittest.mock import Mock, patch, AsyncMock
+from eval.evaluation import LLMEvaluation
+import asyncio
+
+class TestLLMEvaluationIntegration:
+    """LLMEvaluation 통합 테스트 (API 호출 모킹)"""
+    
+    @pytest.fixture
+    def mock_evaluator(self):
+        """모킹된 LLMEvaluation 인스턴스"""
+        with patch('eval.evaluation.load_dataset') as mock_load_dataset, \
+             patch('eval.evaluation.get_config') as mock_config, \
+             patch('eval.evaluation.AsyncOpenAI') as mock_openai:
+            
+            # 데이터셋 모킹
+            mock_dataset = [
+                {
+                    "instruction": "스팸 메시지를 분류하세요.",
+                    "input": "무료 상품!",
+                    "output": "스팸입니다."
+                },
+                {
+                    "instruction": "감정을 분석하세요.",
+                    "input": "좋은 하루네요.",
+                    "output": "긍정적입니다."
+                }
+            ]
+            mock_load_dataset.return_value = mock_dataset
+            
+            # 환경 설정 모킹
+            mock_env = Mock()
+            mock_env.SPAM_MODEL_URL = "http://test.com"
+            mock_env.SPAM_MODEL_API_KEY = "test-key"
+            mock_env.SPAM_MODEL = "test-model"
+            mock_config.return_value = mock_env
+            
+            # OpenAI 클라이언트 모킹
+            mock_client = AsyncMock()
+            mock_openai.return_value = mock_client
+            
+            evaluator = LLMEvaluation()
+            evaluator.dataset = mock_dataset
+            
+            return evaluator, mock_client
+    
+    @pytest.mark.asyncio
+    async def test_evaluate_success(self, mock_evaluator):
+        """성공적인 평가 실행 테스트"""
+        evaluator, mock_client = mock_evaluator
+        
+        # API 응답 모킹
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "예측 결과"
+        mock_client.chat.completions.create.return_value = mock_response
+        
+        # 평가 메트릭 모킹
+        with patch.object(evaluator.bleu, 'score', return_value=0.8), \
+             patch.object(evaluator.rouge, 'score', return_value={'rouge1': 0.7, 'rouge2': 0.6}):
+            
+            results = await evaluator.evaluate()
+        
+        # 검증
+        assert 'BLEU' in results
+        assert 'ROUGE' in results
+        assert results['BLEU'] == 0.8
+        assert results['ROUGE']['rouge1'] == 0.7
+        assert results['ROUGE']['rouge2'] == 0.6
+        
+        # API 호출 횟수 확인 (데이터셋 크기만큼)
+        assert mock_client.chat.completions.create.call_count == 2
+    
+    @pytest.mark.asyncio
+    async def test_evaluate_with_api_errors(self, mock_evaluator):
+        """API 오류가 있는 경우 평가 테스트"""
+        evaluator, mock_client = mock_evaluator
+        
+        # 첫 번째 호출은 실패, 두 번째는 성공
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "예측 결과"
+        
+        mock_client.chat.completions.create.side_effect = [
+            Exception("API Error"),  # 첫 번째 호출 실패
+            mock_response             # 두 번째 호출 성공
+        ]
+        
+        # 평가 메트릭 모킹 (성공한 경우에만)
+        with patch.object(evaluator.bleu, 'score', return_value=0.5), \
+             patch.object(evaluator.rouge, 'score', return_value={'rouge1': 0.4}), \
+             patch('eval.evaluation.logger') as mock_logger:
+            
+            results = await evaluator.evaluate()
+        
+        # 검증
+        assert 'BLEU' in results
+        assert 'ROUGE' in results
+        assert results['BLEU'] == 0.5  # 성공한 하나의 샘플만
+        
+        # 경고 로그가 기록되었는지 확인
+        mock_logger.warning.assert_called_once()
+    
+    @pytest.mark.asyncio
+    async def test_evaluate_all_samples_fail(self, mock_evaluator):
+        """모든 샘플이 실패하는 경우 테스트"""
+        evaluator, mock_client = mock_evaluator
+        
+        # 모든 API 호출 실패
+        mock_client.chat.completions.create.side_effect = Exception("API Error")
+        
+        with patch('eval.evaluation.logger'):
+            with pytest.raises(RuntimeError, match="유효한 샘플이 없어 점수를 계산할 수 없습니다"):
+                await evaluator.evaluate()
+    
+    @pytest.mark.asyncio
+    async def test_evaluate_with_empty_prediction(self, mock_evaluator):
+        """빈 예측 결과 처리 테스트"""
+        evaluator, mock_client = mock_evaluator
+        
+        # 빈 응답 모킹
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "   "  # 공백만 있는 응답
+        mock_client.chat.completions.create.return_value = mock_response
+        
+        # 평가 메트릭 모킹
+        with patch.object(evaluator.bleu, 'score', return_value=0.0), \
+             patch.object(evaluator.rouge, 'score', return_value={'rouge1': 0.0}):
+            
+            results = await evaluator.evaluate()
+        
+        # 검증 - 빈 예측도 처리되어야 함
+        assert 'BLEU' in results
+        assert 'ROUGE' in results
+    
+    def test_module_import_success(self):
+        """모듈 import 성공 테스트 (evaluation.py에는 main이 __name__ == '__main__' 블록에 있음)"""
+        # evaluation.py에는 main 함수가 __name__ == '__main__' 블록 안에 있으므로
+        # 직접 import할 수 없음. 대신 모듈 import가 성공하는지만 확인
+        try:
+            import eval.evaluation
+            assert hasattr(eval.evaluation, 'LLMEvaluation')
+            assert hasattr(eval.evaluation, 'safe_mean')
+        except ImportError:
+            pytest.fail("eval.evaluation 모듈 import 실패")
+    
+    @pytest.mark.asyncio
+    async def test_end_to_end_evaluation_flow(self, mock_evaluator):
+        """전체 평가 플로우 end-to-end 테스트"""
+        evaluator, mock_client = mock_evaluator
+        
+        # 실제 evaluation.py의 main 함수 로직을 시뮬레이션
+        # 1. 평가 인스턴스 생성은 이미 fixture에서 완료
+        
+        # 2. API 응답 모킹
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "스팸 메시지입니다."
+        mock_client.chat.completions.create.return_value = mock_response
+        
+        # 3. 평가 메트릭 모킹
+        with patch.object(evaluator.bleu, 'score', return_value=0.75), \
+             patch.object(evaluator.rouge, 'score', return_value={'rouge1': 0.8, 'rouge2': 0.7}), \
+             patch('eval.evaluation.logger') as mock_logger:
+            
+            # 4. 평가 실행 (main 함수의 핵심 로직)
+            results = await evaluator.evaluate()
+            
+            # 5. 결과 검증 (main 함수에서 로그로 출력하는 부분)
+            assert 'BLEU' in results
+            assert 'ROUGE' in results
+            assert results['BLEU'] == 0.75
+            assert 'rouge1' in results['ROUGE']
+            assert results['ROUGE']['rouge1'] == 0.8
+            
+            # 로그가 기록되었는지 확인하지 않음 (실제 main에서만 로그 출력)
+    
+    @pytest.mark.asyncio
+    async def test_evaluate_temperature_setting(self, mock_evaluator):
+        """temperature=0.0 설정 확인 테스트"""
+        evaluator, mock_client = mock_evaluator
+        
+        # API 응답 모킹
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "예측 결과"
+        mock_client.chat.completions.create.return_value = mock_response
+        
+        # 평가 메트릭 모킹
+        with patch.object(evaluator.bleu, 'score', return_value=0.8), \
+             patch.object(evaluator.rouge, 'score', return_value={'rouge1': 0.7}):
+            
+            await evaluator.evaluate()
+        
+        # temperature=0.0으로 호출되었는지 확인
+        call_args = mock_client.chat.completions.create.call_args_list[0]
+        assert call_args[1]['temperature'] == 0.0
+        assert call_args[1]['model'] == evaluator.model_name

--- a/tests/unit/test_evaluation.py
+++ b/tests/unit/test_evaluation.py
@@ -1,0 +1,315 @@
+import pytest
+from unittest.mock import Mock, patch, AsyncMock
+import asyncio
+from eval.evaluation import LLMEvaluation, safe_mean
+
+
+class TestSafeMean:
+    """safe_mean 함수 단위 테스트"""
+    
+    def test_safe_mean_with_values(self):
+        """값이 있는 리스트의 평균 계산 테스트"""
+        assert safe_mean([1.0, 2.0, 3.0]) == 2.0
+        assert safe_mean([0.5, 1.5]) == 1.0
+        assert safe_mean([10.0]) == 10.0
+    
+    def test_safe_mean_with_empty_list(self):
+        """빈 리스트일 때 0.0 반환 테스트"""
+        assert safe_mean([]) == 0.0
+    
+    def test_safe_mean_with_zeros(self):
+        """0값들의 평균 계산 테스트"""
+        assert safe_mean([0.0, 0.0, 0.0]) == 0.0
+
+
+class TestLLMEvaluationUnit:
+    """LLMEvaluation 클래스 단위 테스트"""
+    
+    @pytest.fixture
+    def mock_dataset(self):
+        """테스트용 데이터셋 픽스처"""
+        return [
+            {
+                "instruction": "스팸 메시지를 분류하세요.",
+                "input": "무료 상품 제공!",
+                "output": "이것은 스팸 메시지입니다."
+            },
+            {
+                "instruction": "메시지의 감정을 분석하세요.",
+                "input": "",
+                "output": "중립적인 메시지입니다."
+            }
+        ]
+    
+    @patch('eval.evaluation.load_dataset')
+    @patch('eval.evaluation.get_config')
+    @patch('eval.evaluation.AsyncOpenAI')
+    def test_init_with_limit(self, mock_openai, mock_config, mock_load_dataset):
+        """limit 파라미터가 있는 생성자 테스트"""
+        # Mock 설정
+        mock_dataset = Mock()
+        mock_dataset.__len__ = Mock(return_value=1000)
+        mock_dataset.select = Mock(return_value=mock_dataset)
+        mock_load_dataset.return_value = mock_dataset
+        
+        mock_env = Mock()
+        mock_env.SPAM_MODEL_URL = "http://test.com"
+        mock_env.SPAM_MODEL_API_KEY = "test-key"
+        mock_env.SPAM_MODEL = "test-model"
+        mock_config.return_value = mock_env
+        
+        # 테스트 실행
+        evaluator = LLMEvaluation(limit=100)
+        
+        # 검증
+        mock_load_dataset.assert_called_once_with("Devocean-06/Spam_QA-Corpus", split="test")
+        mock_dataset.select.assert_called_once_with(range(100))
+        # 실제 환경 설정에서 model_name은 다를 수 있으므로 존재 여부만 확인
+        assert hasattr(evaluator, 'model_name')
+        assert evaluator.model_name is not None
+    
+    @patch('eval.evaluation.load_dataset')
+    @patch('eval.evaluation.get_config')
+    @patch('eval.evaluation.AsyncOpenAI')
+    def test_init_without_limit(self, mock_openai, mock_config, mock_load_dataset):
+        """limit 파라미터가 없는 생성자 테스트"""
+        # Mock 설정
+        mock_dataset = Mock()
+        mock_load_dataset.return_value = mock_dataset
+        
+        mock_env = Mock()
+        mock_env.SPAM_MODEL_URL = "http://test.com"
+        mock_env.SPAM_MODEL_API_KEY = "test-key"
+        mock_env.SPAM_MODEL = "test-model"
+        mock_config.return_value = mock_env
+        
+        # 테스트 실행
+        evaluator = LLMEvaluation(limit=None)
+        
+        # 검증
+        mock_load_dataset.assert_called_once_with("Devocean-06/Spam_QA-Corpus", split="test")
+        mock_dataset.select.assert_not_called()
+    
+    def test_build_prompt_with_input(self):
+        """input이 있는 경우 프롬프트 생성 테스트"""
+        with patch('eval.evaluation.load_dataset'), \
+             patch('eval.evaluation.get_config'), \
+             patch('eval.evaluation.AsyncOpenAI'):
+            
+            evaluator = LLMEvaluation()
+            
+            sample = {
+                "instruction": "스팸 메시지를 분류하세요.",
+                "input": "무료 상품 제공!",
+                "output": "이것은 스팸 메시지입니다."
+            }
+            
+            prompt, reference = evaluator._build_prompt(sample)
+            
+            expected_prompt = "스팸 메시지를 분류하세요.\n\nInput: 무료 상품 제공!"
+            assert prompt == expected_prompt
+            assert reference == "이것은 스팸 메시지입니다."
+    
+    def test_build_prompt_without_input(self):
+        """input이 없는 경우 프롬프트 생성 테스트"""
+        with patch('eval.evaluation.load_dataset'), \
+             patch('eval.evaluation.get_config'), \
+             patch('eval.evaluation.AsyncOpenAI'):
+            
+            evaluator = LLMEvaluation()
+            
+            sample = {
+                "instruction": "메시지의 감정을 분석하세요.",
+                "input": "",
+                "output": "중립적인 메시지입니다."
+            }
+            
+            prompt, reference = evaluator._build_prompt(sample)
+            
+            assert prompt == "메시지의 감정을 분석하세요."
+            assert reference == "중립적인 메시지입니다."
+    
+    def test_build_prompt_strips_whitespace(self):
+        """공백 제거 테스트"""
+        with patch('eval.evaluation.load_dataset'), \
+             patch('eval.evaluation.get_config'), \
+             patch('eval.evaluation.AsyncOpenAI'):
+            
+            evaluator = LLMEvaluation()
+            
+            sample = {
+                "instruction": "  분류하세요.  ",
+                "input": "  테스트 입력  ",
+                "output": "  테스트 출력  "
+            }
+            
+            prompt, reference = evaluator._build_prompt(sample)
+            
+            expected_prompt = "분류하세요.\n\nInput: 테스트 입력"
+            assert prompt == expected_prompt
+            assert reference == "테스트 출력"
+
+
+class TestLLMEvaluationIntegration:
+    """LLMEvaluation 통합 테스트 (API 호출 모킹)"""
+    
+    @pytest.fixture
+    def mock_evaluator(self):
+        """모킹된 LLMEvaluation 인스턴스"""
+        with patch('eval.evaluation.load_dataset') as mock_load_dataset, \
+             patch('eval.evaluation.get_config') as mock_config, \
+             patch('eval.evaluation.AsyncOpenAI') as mock_openai:
+            
+            # 데이터셋 모킹
+            mock_dataset = [
+                {
+                    "instruction": "스팸 메시지를 분류하세요.",
+                    "input": "무료 상품!",
+                    "output": "스팸입니다."
+                },
+                {
+                    "instruction": "감정을 분석하세요.",
+                    "input": "좋은 하루네요.",
+                    "output": "긍정적입니다."
+                }
+            ]
+            mock_load_dataset.return_value = mock_dataset
+            
+            # 환경 설정 모킹
+            mock_env = Mock()
+            mock_env.SPAM_MODEL_URL = "http://test.com"
+            mock_env.SPAM_MODEL_API_KEY = "test-key"
+            mock_env.SPAM_MODEL = "test-model"
+            mock_config.return_value = mock_env
+            
+            # OpenAI 클라이언트 모킹
+            mock_client = AsyncMock()
+            mock_openai.return_value = mock_client
+            
+            evaluator = LLMEvaluation()
+            evaluator.dataset = mock_dataset
+            
+            return evaluator, mock_client
+    
+    @pytest.mark.asyncio
+    async def test_evaluate_success(self, mock_evaluator):
+        """성공적인 평가 실행 테스트"""
+        evaluator, mock_client = mock_evaluator
+        
+        # API 응답 모킹
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "예측 결과"
+        mock_client.chat.completions.create.return_value = mock_response
+        
+        # 평가 메트릭 모킹 (score 메서드 사용)
+        with patch.object(evaluator.bleu, 'score', return_value=0.8), \
+             patch.object(evaluator.rouge, 'score', return_value={'rouge1': 0.7, 'rouge2': 0.6}):
+            
+            results = await evaluator.evaluate()
+        
+        # 검증
+        assert 'BLEU' in results
+        assert 'ROUGE' in results
+        assert results['BLEU'] == 0.8
+        assert results['ROUGE']['rouge1'] == 0.7
+        assert results['ROUGE']['rouge2'] == 0.6
+        
+        # API 호출 횟수 확인 (데이터셋 크기만큼)
+        assert mock_client.chat.completions.create.call_count == 2
+    
+    @pytest.mark.asyncio
+    async def test_evaluate_with_api_errors(self, mock_evaluator):
+        """API 오류가 있는 경우 평가 테스트"""
+        evaluator, mock_client = mock_evaluator
+        
+        # 첫 번째 호출은 실패, 두 번째는 성공
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "예측 결과"
+        
+        mock_client.chat.completions.create.side_effect = [
+            Exception("API Error"),  # 첫 번째 호출 실패
+            mock_response             # 두 번째 호출 성공
+        ]
+        
+        # 평가 메트릭 모킹 (성공한 경우에만)
+        with patch.object(evaluator.bleu, 'score', return_value=0.5), \
+             patch.object(evaluator.rouge, 'score', return_value={'rouge1': 0.4}), \
+             patch('eval.evaluation.logger') as mock_logger:
+            
+            results = await evaluator.evaluate()
+        
+        # 검증
+        assert 'BLEU' in results
+        assert 'ROUGE' in results
+        assert results['BLEU'] == 0.5  # 성공한 하나의 샘플만
+        
+        # 경고 로그가 기록되었는지 확인
+        mock_logger.warning.assert_called_once()
+    
+    @pytest.mark.asyncio
+    async def test_evaluate_all_samples_fail(self, mock_evaluator):
+        """모든 샘플이 실패하는 경우 테스트"""
+        evaluator, mock_client = mock_evaluator
+        
+        # 모든 API 호출 실패
+        mock_client.chat.completions.create.side_effect = Exception("API Error")
+        
+        with patch('eval.evaluation.logger'):
+            with pytest.raises(RuntimeError, match="유효한 샘플이 없어 점수를 계산할 수 없습니다"):
+                await evaluator.evaluate()
+    
+    @pytest.mark.asyncio
+    async def test_evaluate_with_empty_prediction(self, mock_evaluator):
+        """빈 예측 결과 처리 테스트"""
+        evaluator, mock_client = mock_evaluator
+        
+        # 빈 응답 모킹
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "   "  # 공백만 있는 응답
+        mock_client.chat.completions.create.return_value = mock_response
+        
+        # 평가 메트릭 모킹
+        with patch.object(evaluator.bleu, 'score', return_value=0.0), \
+             patch.object(evaluator.rouge, 'score', return_value={'rouge1': 0.0}):
+            
+            results = await evaluator.evaluate()
+        
+        # 검증 - 빈 예측도 처리되어야 함
+        assert 'BLEU' in results
+        assert 'ROUGE' in results
+    
+    def test_module_import_success(self):
+        """모듈 import 성공 테스트"""
+        # evaluation.py에는 main 함수가 __name__ == '__main__' 블록 안에 있으므로
+        # 직접 import할 수 없음. 대신 모듈 import가 성공하는지만 확인
+        try:
+            import eval.evaluation
+            assert hasattr(eval.evaluation, 'LLMEvaluation')
+            assert hasattr(eval.evaluation, 'safe_mean')
+        except ImportError:
+            pytest.fail("eval.evaluation 모듈 import 실패")
+    
+    @pytest.mark.asyncio
+    async def test_evaluate_temperature_setting(self, mock_evaluator):
+        """temperature=0.0 설정 확인 테스트"""
+        evaluator, mock_client = mock_evaluator
+        
+        # API 응답 모킹
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "예측 결과"
+        mock_client.chat.completions.create.return_value = mock_response
+        
+        # 평가 메트릭 모킹
+        with patch.object(evaluator.bleu, 'score', return_value=0.8), \
+             patch.object(evaluator.rouge, 'score', return_value={'rouge1': 0.7}):
+            
+            await evaluator.evaluate()
+        
+        # temperature=0.0으로 호출되었는지 확인
+        call_args = mock_client.chat.completions.create.call_args_list[0]
+        assert call_args[1]['temperature'] == 0.0
+        assert call_args[1]['model'] == evaluator.model_name


### PR DESCRIPTION
## 📖 개요
- `LLMEvaluation` 클래스의 `evaluate` 메서드에 대한 테스트 코드 작성
- BLEU, ROUGE 등 휴리스틱 지표 계산 로직의 정상 동작 검증
- 외부 API 호출(vLLM) 부분은 `AsyncMock`으로 대체하여 재현성 보장

---

## 🔧 변경 사항
- `tests/integration/test_llm_evaluation.py` 파일 추가
- `AsyncMock` 기반 vLLM API 응답 stub 구현
- BLEU/ROUGE 점수 평균 산출 로직 단위 검증

---


## 테스트 결과
<img width="1380" height="526" alt="image" src="https://github.com/user-attachments/assets/acccf4d7-e48c-4d2f-974d-6e3a6866ddc4" />
